### PR TITLE
필드명이 id가 아닌 필드 접근 불가 및 super super class의 필드 접근 못하는 이슈 해결

### DIFF
--- a/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/EntityAuditing2.java
+++ b/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/EntityAuditing2.java
@@ -1,0 +1,20 @@
+package org.springframework.batch.item.querydsl.integrationtest.entity;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+abstract class EntityAuditing2 extends EntityAuditing {
+
+    @Column
+    private Long id2;
+
+    public Long getId2() {
+        return id2;
+    }
+}

--- a/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/Foo2.java
+++ b/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/Foo2.java
@@ -9,11 +9,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Foo extends EntityAuditing {
+public class Foo2 extends EntityAuditing2 {
 
     private String name;
 
-    public Foo(String name) {
+    public Foo2(String name) {
         this.name = name;
     }
 }

--- a/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/Foo2Repository.java
+++ b/spring-batch-querydsl-integration-test/src/main/java/org/springframework/batch/item/querydsl/integrationtest/entity/Foo2Repository.java
@@ -1,0 +1,6 @@
+package org.springframework.batch.item.querydsl.integrationtest.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface Foo2Repository extends JpaRepository<Foo2, Long> {
+}

--- a/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
+++ b/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
@@ -2,6 +2,7 @@ package org.springframework.batch.item.querydsl.integrationtest.reader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.batch.item.querydsl.integrationtest.entity.QFoo.foo;
+import static org.springframework.batch.item.querydsl.integrationtest.entity.QFoo2.foo2;
 import static org.springframework.batch.item.querydsl.integrationtest.entity.QManufacture.manufacture;
 
 import java.time.LocalDate;
@@ -12,6 +13,8 @@ import org.junit.runner.RunWith;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.querydsl.integrationtest.TestBatchConfig;
 import org.springframework.batch.item.querydsl.integrationtest.entity.Foo;
+import org.springframework.batch.item.querydsl.integrationtest.entity.Foo2;
+import org.springframework.batch.item.querydsl.integrationtest.entity.Foo2Repository;
 import org.springframework.batch.item.querydsl.integrationtest.entity.FooRepository;
 import org.springframework.batch.item.querydsl.integrationtest.entity.Manufacture;
 import org.springframework.batch.item.querydsl.integrationtest.entity.ManufactureRepository;
@@ -33,6 +36,9 @@ public class QuerydslNoOffsetPagingItemReaderGroupByTest {
 
     @Autowired
     private FooRepository fooRepository;
+
+    @Autowired
+    private Foo2Repository foo2Repository;
 
     @Autowired
     private EntityManagerFactory emf;
@@ -130,6 +136,28 @@ public class QuerydslNoOffsetPagingItemReaderGroupByTest {
 
         //when
         final Foo foo = reader.read();
+
+        reader.close();
+
+        //then
+        assertThat(foo.getId()).isEqualTo(fooId);
+    }
+
+    @Test
+    public void super_super_class의_필드_사용_가능하다() throws Exception {
+        //given
+        int chunkSize = 1;
+        final Long fooId = foo2Repository.save(new Foo2("foo2")).getId();
+
+        final QuerydslNoOffsetNumberOptions<Foo2, Long> options = new QuerydslNoOffsetNumberOptions<>(foo2.id, Expression.DESC);
+        final QuerydslNoOffsetPagingItemReader<Foo2> reader = new QuerydslNoOffsetPagingItemReader<>(emf, chunkSize, options, queryFactory -> queryFactory
+                .selectFrom(foo2)
+                .where(foo2.id.eq(fooId))
+        );
+        reader.open(new ExecutionContext());
+
+        //when
+        final Foo2 foo = reader.read();
 
         reader.close();
 

--- a/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
+++ b/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderGroupByTest.java
@@ -71,6 +71,8 @@ public class QuerydslNoOffsetPagingItemReaderGroupByTest {
         Manufacture read2 = reader.read();
         Manufacture read3 = reader.read();
 
+        reader.close();
+
         //then
         assertThat(read1.getName()).isEqualTo(expected1);
         assertThat(read2.getName()).isEqualTo(expected2);
@@ -105,6 +107,8 @@ public class QuerydslNoOffsetPagingItemReaderGroupByTest {
         Manufacture read2 = reader.read();
         Manufacture read3 = reader.read();
 
+        reader.close();
+
         //then
         assertThat(read1.getName()).isEqualTo(expected2);
         assertThat(read2.getName()).isEqualTo(expected1);
@@ -118,10 +122,7 @@ public class QuerydslNoOffsetPagingItemReaderGroupByTest {
         final Long fooId = fooRepository.save(new Foo("foo1")).getId();
 
         final QuerydslNoOffsetNumberOptions<Foo, Long> options = new QuerydslNoOffsetNumberOptions<>(foo.id, Expression.DESC);
-        final QuerydslNoOffsetPagingItemReader<Foo> reader = new QuerydslNoOffsetPagingItemReader<>(emf,
-            chunkSize,
-            options,
-            queryFactory -> queryFactory
+        final QuerydslNoOffsetPagingItemReader<Foo> reader = new QuerydslNoOffsetPagingItemReader<>(emf, chunkSize, options, queryFactory -> queryFactory
                 .selectFrom(foo)
                 .where(foo.id.eq(fooId))
         );
@@ -129,6 +130,8 @@ public class QuerydslNoOffsetPagingItemReaderGroupByTest {
 
         //when
         final Foo foo = reader.read();
+
+        reader.close();
 
         //then
         assertThat(foo.getId()).isEqualTo(fooId);

--- a/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderTest.java
+++ b/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslNoOffsetPagingItemReaderTest.java
@@ -112,6 +112,8 @@ public class QuerydslNoOffsetPagingItemReaderTest {
         Manufacture read2 = reader.read();
         Manufacture read3 = reader.read();
 
+        reader.close();
+
         //then
         assertThat(read1.getPrice()).isEqualTo(expected1);
         assertThat(read2.getPrice()).isEqualTo(expected2);
@@ -144,6 +146,8 @@ public class QuerydslNoOffsetPagingItemReaderTest {
         Manufacture read2 = reader.read();
         Manufacture read3 = reader.read();
 
+        reader.close();
+
         //then
         assertThat(read1.getPrice()).isEqualTo(expected2);
         assertThat(read2.getPrice()).isEqualTo(expected1);
@@ -167,6 +171,8 @@ public class QuerydslNoOffsetPagingItemReaderTest {
 
         //when
         Manufacture read1 = reader.read();
+
+        reader.close();
 
         //then
         assertThat(read1).isNull();
@@ -201,6 +207,8 @@ public class QuerydslNoOffsetPagingItemReaderTest {
         Manufacture read3 = reader.read();
         Manufacture read4 = reader.read();
 
+        reader.close();
+
         //then
         assertThat(read1.getPrice()).isEqualTo(expected1);
         assertThat(read2.getPrice()).isEqualTo(expected2);
@@ -234,6 +242,8 @@ public class QuerydslNoOffsetPagingItemReaderTest {
         Manufacture read2 = reader.read();
         Manufacture read3 = reader.read();
 
+        reader.close();
+
         //then
         assertThat(read1.getCategoryNo()).isEqualTo(expected2);
         assertThat(read2.getCategoryNo()).isEqualTo(expected1);
@@ -257,6 +267,8 @@ public class QuerydslNoOffsetPagingItemReaderTest {
 
         //when
         Manufacture read1 = reader.read();
+
+        reader.close();
 
         //then
         assertThat(read1).isNull();
@@ -287,6 +299,8 @@ public class QuerydslNoOffsetPagingItemReaderTest {
         Manufacture read1 = reader.read();
         Manufacture read2 = reader.read();
         Manufacture read3 = reader.read();
+
+        reader.close();
 
         //then
         assertThat(read1.getName()).isEqualTo(expected2);
@@ -319,6 +333,8 @@ public class QuerydslNoOffsetPagingItemReaderTest {
         Manufacture read1 = reader.read();
         Manufacture read2 = reader.read();
         Manufacture read3 = reader.read();
+
+        reader.close();
 
         //then
         assertThat(read1.getName()).isEqualTo(expected1);

--- a/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslPagingItemReaderTest.java
+++ b/spring-batch-querydsl-integration-test/src/test/java/org/springframework/batch/item/querydsl/integrationtest/reader/QuerydslPagingItemReaderTest.java
@@ -63,6 +63,8 @@ public class QuerydslPagingItemReaderTest {
         Manufacture read2 = reader.read();
         Manufacture read3 = reader.read();
 
+        reader.close();
+
         //then
         assertThat(read1.getPrice()).isEqualTo(expected1);
         assertThat(read2.getPrice()).isEqualTo(expected2);
@@ -84,6 +86,8 @@ public class QuerydslPagingItemReaderTest {
 
         //when
         Manufacture read1 = reader.read();
+
+        reader.close();
 
         //then
         assertThat(read1).isNull();

--- a/spring-batch-querydsl-reader/src/main/java/org/springframework/batch/item/querydsl/reader/options/QuerydslNoOffsetOptions.java
+++ b/spring-batch-querydsl-reader/src/main/java/org/springframework/batch/item/querydsl/reader/options/QuerydslNoOffsetOptions.java
@@ -41,22 +41,17 @@ public abstract class QuerydslNoOffsetOptions<T> {
 
     protected Object getFiledValue(T item) {
         try {
-            final Class<?> itemClass = item.getClass();
-            if (itemClass.getSuperclass() != null) {
-                final Class<?> superclass = itemClass.getSuperclass();
-                final Field[] superClassFields = superclass.getDeclaredFields();
-                for (Field field : superClassFields) {
-                    if (field.getName().equals(fieldName)) {
-                        field.setAccessible(true);
-                        superclass.getDeclaredField("id");
-                        return field.get(item);
-                    }
+            Class<?> itemClass = item.getClass();
+            while (itemClass != null) {
+                try {
+                    Field field = itemClass.getDeclaredField(fieldName);
+                    field.setAccessible(true);
+                    return field.get(item);
+                } catch (NoSuchFieldException e) {
+                    itemClass = itemClass.getSuperclass();
                 }
             }
-
-            final Field field = itemClass.getDeclaredField("id");
-            field.setAccessible(true);
-            return field.get(item);
+            throw new NoSuchFieldException(fieldName);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             logger.error("Not Found or Not Access Field= " + fieldName, e);
             throw new IllegalArgumentException("Not Found or Not Access Field");


### PR DESCRIPTION
## 증상

- 테스트 코드에서 HikariCP의 Connection을 리턴하지 않아 몇몇 테스트가 커넥션을 사용하지 못해 실패하는 이슈
- `QuerydslNoOffsetStringOptions` 생성자 매개변수 field에 명칭이 `id`가 아닌 필드 넘길 시 인식 못하는 이슈

## 해결

```java
reader.open(new ExecutionContext());

//when
Manufacture read1 = reader.read();
Manufacture read2 = reader.read();
Manufacture read3 = reader.read();

reader.close(); // 추가
```

- `reader.close()` 처리 추가

---

```java
protected Object getFiledValue(T item) {
    try {
        Class<?> itemClass = item.getClass();
        while (itemClass != null) {
            try {
                Field field = itemClass.getDeclaredField(fieldName);
                field.setAccessible(true);
                return field.get(item);
            } catch (NoSuchFieldException e) {
                itemClass = itemClass.getSuperclass();
            }
        }
        throw new NoSuchFieldException(fieldName);
    } catch (NoSuchFieldException | IllegalAccessException e) {
        logger.error("Not Found or Not Access Field= " + fieldName, e);
        throw new IllegalArgumentException("Not Found or Not Access Field");
    }
}
```

- while 문을 통해 클래스 계층 구조 최상단까지 탐색하도록 수정
- `superclass.getDeclaredField("id")` -> `superclass.getDeclaredField(fieldName)`